### PR TITLE
Do not override false settings value

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -49,7 +49,11 @@ var __deepDefaults = function (settings, node) {
       __deepDefaults(settings[key], node);
     }
     else {
-      settings[key] = settings[key] || node;
+      // if the value at key is undefined use the default node passed in
+      if (_.isUndefined(settings[key]))
+        settings[key] = node;
+      else
+        settings[key] = settings[key];
     }
   });
 };

--- a/src/settings_tests.js
+++ b/src/settings_tests.js
@@ -259,3 +259,17 @@ Tinytest.add("Two identical values", function (test) {
 
   MeteorSettings.setDefaults( defaults );
 });
+
+Tinytest.add("Do not overide a false property", function (test) {
+
+  Meteor.settings = { public: { useUniqueBlogPostsPath: false } };
+
+  var expected = _.clone( Meteor.settings );
+
+  var defaults = { public: { useUniqueBlogPostsPath: true } };
+
+  MeteorSettings.setDefaults( defaults );
+
+  test.equal( Meteor.settings, expected );
+
+});


### PR DESCRIPTION
Hello, thank you for writing such an awesome, convenience package.

I ran into some trouble when using the package inside the xolvio:md-blog package. I had set a property to be false and the `MeteorSettings.default` would overwrite the property to be true every time.

Please review the new logic to determine if to use the default property or not.
